### PR TITLE
chore(packwiz): no internal hashes

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -2,446 +2,356 @@ hash-format = "sha256"
 
 [[files]]
 file = "LICENSE"
-hash = "01e95ac360b6293e22377aac91494120076a922c3e030766d2ad79d9329b6681"
 
 [[files]]
 file = "config/forgery/features.ini"
-hash = "96addbc712254a3ea0af06709df13079c4cc9b55d215896063a52dd8a5def4d3"
 
 [[files]]
 file = "kubejs/README.txt"
-hash = "989f3737ae4621b8ff6730bce4cbeeee756921e7e510e0c281c8a350501d98af"
 
 [[files]]
 file = "kubejs/server_scripts/server.js"
-hash = "871dee465c0d596b84dcb9ac8cdad686b31c320ee66c51acf1ab0384cb28adee"
 
 [[files]]
 file = "mods/ad-astra.pw.toml"
-hash = "9931ba04fc0f075c9d132714dc703b08cd11aaab27a7db9b28d6c4fa79eb50b2"
 metafile = true
 
 [[files]]
 file = "mods/ae2.pw.toml"
-hash = "0404df67b1976c2bc5cbbf43af1c1a2e64d729f82213d0452f89baa0157f2d60"
 metafile = true
 
 [[files]]
 file = "mods/appleskin.pw.toml"
-hash = "1e876f20f5d441f1ba1fdbae58bd6c8679a9664ac41e0a4b57964530ff0205b8"
 metafile = true
 
 [[files]]
 file = "mods/architectury-api.pw.toml"
-hash = "8c8f8222d0a2c3e1f673b137637b17bd87535b0aad111d79e242f18af48d0169"
 metafile = true
 
 [[files]]
 file = "mods/autoreglib.pw.toml"
-hash = "2264acfbd388023f4c11b06b18e1a8b79b2b078e9fbf4cc38b31e4cb31c653dd"
 metafile = true
 
 [[files]]
 file = "mods/better-advancements.pw.toml"
-hash = "d00e0c99eaf65566c8c26a95c11bda8c31d2b4cc868681b29f09871bc7e6bb66"
 metafile = true
 
 [[files]]
 file = "mods/blahaj-reforged.pw.toml"
-hash = "7b3e32d4e527b915afb6d611b3f49fccd29cc1ccbc8442d251eef0671f97d692"
 metafile = true
 
 [[files]]
 file = "mods/botarium.pw.toml"
-hash = "59512015694bd675c63264984669249c8190a37802427e7875b7f2d21d69e033"
 metafile = true
 
 [[files]]
 file = "mods/building-gadgets.pw.toml"
-hash = "d07aad009ac2e58a667d5893e862ab362db02e1ba104aa2dfd65337afb3551e6"
 metafile = true
 
 [[files]]
 file = "mods/canary.pw.toml"
-hash = "d8002b0ef28a23ea952c687a29d7fcd3c6973eef02b4c513b9d1b2d9b163ed3c"
 metafile = true
 
 [[files]]
 file = "mods/chat-heads.pw.toml"
-hash = "6b13420e812b4e9307fb162490f7624e9167daa04073d16d1140e851fe70841b"
 metafile = true
 
 [[files]]
 file = "mods/cloth-config.pw.toml"
-hash = "fe2b1cb8e815ed0fb5fbc46cb808411237f1694dce52f87242a1798fffcfc558"
 metafile = true
 
 [[files]]
 file = "mods/clumps.pw.toml"
-hash = "7b6410313b56bb649285417562e45892da293d38b80e185c2ffc52b4f97f680e"
 metafile = true
 
 [[files]]
 file = "mods/cofh-core.pw.toml"
-hash = "828e6940eb60f08488cb0b477530ea82bd3ec631547a279590603cf7e20de9ff"
 metafile = true
 
 [[files]]
 file = "mods/controlling.pw.toml"
-hash = "7342959eb86faf584e6d64417064dd793ae6b4667f51954f4169d11fe5f0d5da"
 metafile = true
 
 [[files]]
 file = "mods/corpse.pw.toml"
-hash = "949bf41349bbdfbc8b86379546d30ad19253719c38163e25245e7443bcdaa2e4"
 metafile = true
 
 [[files]]
 file = "mods/create-connected.pw.toml"
-hash = "807e91eda37b895410e3be0c9bc4b664af03fb17d59bec30ee2aa0b0f80628af"
 metafile = true
 
 [[files]]
 file = "mods/create-deco.pw.toml"
-hash = "b0bb61105e0ac0c763edfa41ea5b0406f157bc17e421af1bf8b2cbb49325ced6"
 metafile = true
 
 [[files]]
 file = "mods/create-enchantment-industry.pw.toml"
-hash = "8db857d646fa9bc201fc1f2747d82ab8bbb69b98fa1d79a4d88fe0800071758e"
 metafile = true
 
 [[files]]
 file = "mods/create-mechanical-spawner.pw.toml"
-hash = "58aff494a185f0eb8f2062465e66412c18320c58c40682855a2394312534c158"
 metafile = true
 
 [[files]]
 file = "mods/create-metallurgy.pw.toml"
-hash = "a31cecd1e29df0c562c412310f4e3aa811d3d4532bb3f2c8c762ad04bbc90a10"
 metafile = true
 
 [[files]]
 file = "mods/create-ore-excavation.pw.toml"
-hash = "dc14acfaaa1ddb6bc9a9f3550e92ab24e947cade2935615f41111e1e7ae32277"
 metafile = true
 
 [[files]]
 file = "mods/create-teleporters.pw.toml"
-hash = "4a5c24dfdc441bc675aa5b675de46c2921f310b3686cdcf54c1e6cf43718f89e"
 metafile = true
 
 [[files]]
 file = "mods/create.pw.toml"
-hash = "8f7b16bd319a4c534acbc80f83e4359b756b301c76444d5a0afa1d1cb45d20a4"
 metafile = true
 
 [[files]]
 file = "mods/cupboard.pw.toml"
-hash = "278f53824f79ac545293d8fc3e73742a1a3f9d72cb708e48b598b523bc037df2"
 metafile = true
 
 [[files]]
 file = "mods/curios.pw.toml"
-hash = "912491bb046d36a1763a7891ebb176594db759d63072e874cdcefe25d5574a09"
 metafile = true
 
 [[files]]
 file = "mods/ears.pw.toml"
-hash = "e8522704a705980fdc5e35a8c8cb4083fa8cd1a20ac358b6e4c5f8a898f071eb"
 metafile = true
 
 [[files]]
 file = "mods/embeddium.pw.toml"
-hash = "1bfc59cceb5c333b45f06ba231b3ca7ba1ed80354f9e685f73fa7f3174b2f712"
 metafile = true
 
 [[files]]
 file = "mods/entityculling.pw.toml"
-hash = "ea0d8c35669646b8d739a20b97a28c48744dcdea889ccc3c39ccd1431bf5cc6c"
 metafile = true
 
 [[files]]
 file = "mods/extended-cogwheels.pw.toml"
-hash = "11696288bc3f2f91bfd7f1c82fbe98c34bbbfa0c79561ecafcefd7e57969b8be"
 metafile = true
 
 [[files]]
 file = "mods/fabrication.pw.toml"
-hash = "bd3df70768fb7977f4284628616ea8221160f7eedc9631d92144a5feb0041a74"
 metafile = true
 
 [[files]]
 file = "mods/fallingleavesforge.pw.toml"
-hash = "e32f9d59ade1b79276e929121f03712e22395b1238e06ec8ae0a7550ac6d6ec4"
 metafile = true
 
 [[files]]
 file = "mods/farmers-delight.pw.toml"
-hash = "3996a699533ac6cc063f839f53bd5b10036f5e71ab735da9d96dfea8f1ce56a9"
 metafile = true
 
 [[files]]
 file = "mods/fastload.pw.toml"
-hash = "ab6d5c5981eb90445718e5224c7e92a04e4f180373b11fc944d7dce43c704318"
 metafile = true
 
 [[files]]
 file = "mods/fastsuite.pw.toml"
-hash = "6ec4fcec4795f75ffdb7333316b4a40acb97bd4e5560d0ea437d477358b10d87"
 metafile = true
 
 [[files]]
 file = "mods/ferrite-core.pw.toml"
-hash = "ed6f0207affbcdbc338b0af19a596451230a25255f425b3b4670a0104368c95c"
 metafile = true
 
 [[files]]
 file = "mods/ftb-chunks-forge.pw.toml"
-hash = "236e756b439335effde72db4bcedc98456b0ce2baa6090abc2a5406ef5daef9a"
 metafile = true
 
 [[files]]
 file = "mods/ftb-library-forge.pw.toml"
-hash = "879813604dd833f793d6d362c6b8a13ce35bf41da13d921b1e4e6c67813ceace"
 metafile = true
 
 [[files]]
 file = "mods/ftb-quests-forge.pw.toml"
-hash = "b1764406aa98d62b756ad287f9164e84e76d44493dad9335578953465d6f22cb"
 metafile = true
 
 [[files]]
 file = "mods/ftb-teams-forge.pw.toml"
-hash = "c0405f2f156703f6c5a181c18e96dfdbad8760c04ff3be8c088853c7b14572df"
 metafile = true
 
 [[files]]
 file = "mods/fusion-connected-textures.pw.toml"
-hash = "c9ef346647b6d4ed7417f27768461cae6496449b74258b6d81c560e95259c9dd"
 metafile = true
 
 [[files]]
 file = "mods/geckolib.pw.toml"
-hash = "cf303e609b0beaf097122eecfa869d21be642e22465021f4f5aa0fa38c72b119"
 metafile = true
 
 [[files]]
 file = "mods/harvest-with-ease.pw.toml"
-hash = "7cf489e054f61f32333feab802c59c7760b8fce70ed819ca47fdf41baf399d99"
 metafile = true
 
 [[files]]
 file = "mods/inventory-sorter.pw.toml"
-hash = "b278c5bbfd28feeb69a54f3bd9ad1693e77f348dc7b9727888d6334f94997bae"
 metafile = true
 
 [[files]]
 file = "mods/item-filters.pw.toml"
-hash = "e00e666fc6f0726fcca0f74f9252ba4b1022326ee65433b5aaa08bcd14f4390b"
 metafile = true
 
 [[files]]
 file = "mods/jade-addons-forge.pw.toml"
-hash = "c11011cc9fb5bd521e5805e732dd131357ae8fb21f682a7ab2db4aa8ad9a0e41"
 metafile = true
 
 [[files]]
 file = "mods/jade.pw.toml"
-hash = "77197d1980dbae42a4bd5dce2cc5c162c9487e46178e3a528bb82fb136c18243"
 metafile = true
 
 [[files]]
 file = "mods/just-zoom.pw.toml"
-hash = "ed9294e17b26a43a4740fc020b18863166894d08103e93290993c1344ea37620"
 metafile = true
 
 [[files]]
 file = "mods/konkrete.pw.toml"
-hash = "aa241e1683fe80eee9cb233d2a1685e4ee771f85723db9861c168be584d60c60"
 metafile = true
 
 [[files]]
 file = "mods/kotlin-for-forge.pw.toml"
-hash = "94d853ec0def62adb527aee046f2c4a32127076c2995ea5c29553534544e1c35"
 metafile = true
 
 [[files]]
 file = "mods/kubejs-create.pw.toml"
-hash = "df3ac07f9607b2e97ffdf1f4b8b576662fa30e283dee5c8f64e9dd20f2398a36"
 metafile = true
 
 [[files]]
 file = "mods/kubejs.pw.toml"
-hash = "2ca46f6c0e4176bad50a882b4bf1db0daf5cd271142b81644837b2fe2c9f3cee"
 metafile = true
 
 [[files]]
 file = "mods/leaves-be-gone.pw.toml"
-hash = "338e95818aa7bdafffa43ff65a5779e4852fa185325ebfe28f86f5a354c3b22d"
 metafile = true
 
 [[files]]
 file = "mods/lmd.pw.toml"
-hash = "9116ead38df9119fa9d8103c214482aedab1505554865cac1b3bd385019076bd"
 metafile = true
 
 [[files]]
 file = "mods/lootr.pw.toml"
-hash = "ee7ab510ed54a662964184e366cb998e79df9a5ea4799b52a2426750a66ec083"
 metafile = true
 
 [[files]]
 file = "mods/mouse-tweaks.pw.toml"
-hash = "9cba22bdbc8c89d44438b1e22ae677f7d6bf1c7f1adecfff2760427f2d974dee"
 metafile = true
 
 [[files]]
 file = "mods/no-chat-reports.pw.toml"
-hash = "9055b4a92e2ea4ad8661c226f549040eb48ae535070942a3a95b019c08ca70f6"
 metafile = true
 
 [[files]]
 file = "mods/no-mo-portals.pw.toml"
-hash = "39ba25da9497dd738551e9df69bae33d129ac8be34aef3b111687f4f5f43742d"
 metafile = true
 
 [[files]]
 file = "mods/ping-wheel.pw.toml"
-hash = "608d611021d1846d054a1e2cd2991ee908a632144cc15465ce01ca5ef44fafe8"
 metafile = true
 
 [[files]]
 file = "mods/placebo.pw.toml"
-hash = "954c1b5e2a9f16c08027875d6ee536058e617f644e7ed0f83915b4a504015364"
 metafile = true
 
 [[files]]
 file = "mods/polymorph.pw.toml"
-hash = "acf3d6451ac44c6ae1c17f50b65eb8495ed24f851f818f45346a15d93696f611"
 metafile = true
 
 [[files]]
 file = "mods/probejs.pw.toml"
-hash = "54ea764147bb6bcce37550fa8676ec0c88b440681333123d5f3dc342325d23f0"
 metafile = true
 
 [[files]]
 file = "mods/puzzles-lib.pw.toml"
-hash = "827b361fcddfa0bdb84bfa0ebf0e1a38b139804c92aaf9e39218d784e4111fb4"
 metafile = true
 
 [[files]]
 file = "mods/quark.pw.toml"
-hash = "c683cb91014392a4478573dcb54a22a64fdae1c04f998cd95b2e39bf313bdf1d"
 metafile = true
 
 [[files]]
 file = "mods/rechiseled-create.pw.toml"
-hash = "025fc5a67e964df180043021c826a9069537a516505db30d9f18a0822fe61f28"
 metafile = true
 
 [[files]]
 file = "mods/rechiseled.pw.toml"
-hash = "02a4e039263330615ed6d5a7afb142c9df78f6dad431e05f13ebd329f4acef83"
 metafile = true
 
 [[files]]
 file = "mods/rei.pw.toml"
-hash = "53d4cbdcde51508f37bf84b019fbd2721277661c9d45a736770fde67b14a997f"
 metafile = true
 
 [[files]]
 file = "mods/resourceful-config.pw.toml"
-hash = "b551987417640fee1dd523b43db90757bbc0377be7638fff3b0d76a6b7785c93"
 metafile = true
 
 [[files]]
 file = "mods/resourceful-lib.pw.toml"
-hash = "7089cdcaf2c1f1b9f6a9a28195c6925cda1af4dce16fd9f6f241d6340d5c8911"
 metafile = true
 
 [[files]]
 file = "mods/rhino.pw.toml"
-hash = "e3467bb2df661b312db375f7172b6297a8dd9e9a03924d689e70977f71283d89"
 metafile = true
 
 [[files]]
 file = "mods/rubidium-extra.pw.toml"
-hash = "6132d007267c3b5ad0634d2bd6e866357cfe387450ff1362e76732c75b4ea29f"
 metafile = true
 
 [[files]]
 file = "mods/shutup-experimental-settings.pw.toml"
-hash = "97fecd322567a954ea537e61feb6e0f848f307790d2e8a155af427c5910a4a4d"
 metafile = true
 
 [[files]]
 file = "mods/slice-and-dice.pw.toml"
-hash = "6b18e2055cddb936210b4f5a81374e509f32513c2716f7d240647e04b17109aa"
 metafile = true
 
 [[files]]
 file = "mods/smooth-chunk-save.pw.toml"
-hash = "8d50dd4668b13a86e61d7c081e2892b64f19f2d79919020c5902d684e03522e0"
 metafile = true
 
 [[files]]
 file = "mods/sophisticated-backpacks.pw.toml"
-hash = "73649d35fa03c369a4efddd357a830fc5cda7e6217a3fc8cea2072049b70987c"
 metafile = true
 
 [[files]]
 file = "mods/sophisticated-core.pw.toml"
-hash = "4fd88e71474d28d95569b6334fe663c619e504834e63fc26533936143e7d9521"
 metafile = true
 
 [[files]]
 file = "mods/spark.pw.toml"
-hash = "61799bc6367ee86a72fe54b131576cbbc6f4dbe1a1a134d561e83b02a72691be"
 metafile = true
 
 [[files]]
 file = "mods/storage-drawers.pw.toml"
-hash = "11332954f108106789ad818138a9b6ee0dd169a92b8763ae35d2d9ce88815c23"
 metafile = true
 
 [[files]]
 file = "mods/supermartijn642s-config-lib.pw.toml"
-hash = "398222d52f12efff3677e283566822a2766a68d98267261c916eda974a899c27"
 metafile = true
 
 [[files]]
 file = "mods/supermartijn642s-core-lib.pw.toml"
-hash = "0bd8c291f5e00f334f49cd0dbbfa96af803a1f5da844003aafd7829d814974a5"
 metafile = true
 
 [[files]]
 file = "mods/terralith.pw.toml"
-hash = "64228ac782b244019e700da682e0006e9959f472035252c5a5354e0dc395d1e0"
 metafile = true
 
 [[files]]
 file = "mods/thermal-expansion.pw.toml"
-hash = "a6eb809941af324a1cb499e32974e718ef1827eecb4270ee5dd209edc237b8f8"
 metafile = true
 
 [[files]]
 file = "mods/thermal-foundation.pw.toml"
-hash = "a886cd2449393f692f22b97f094ea91a7faf2c4fdd9f72885d5fa6eb299a261b"
 metafile = true
 
 [[files]]
 file = "mods/toms-storage.pw.toml"
-hash = "2033724e9709c1ccb35bbf7a116d5a9eac04c5267865a2dbeea89bab3a2ffbe8"
 metafile = true
 
 [[files]]
 file = "mods/torchmaster.pw.toml"
-hash = "abf3caed290977a3943d18ba395ad9c8d363c73b3cf74aed7aa5ad8c374f2e18"
 metafile = true
 
 [[files]]
 file = "mods/trash-cans.pw.toml"
-hash = "70d2151591356fb60fe868627cc07ccaae1ad41e6a9973678a7610c25e41231b"
 metafile = true

--- a/pack.toml
+++ b/pack.toml
@@ -6,8 +6,10 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "145a94c844cfa5b354a847b550c34d602e67c4f6c31d658ef7be5d781f40af29"
 
 [versions]
 forge = "43.3.0"
 minecraft = "1.19.2"
+
+[options]
+no-internal-hashes = true


### PR DESCRIPTION
Tells packwiz to not generate internal hashes.
Makes it easier to merge and commit files.
Packwiz will add these pack when packwiz-installer gets the pack.toml so make sure to run packwiz refresh before commiting.