### PR TITLE
fix: create recipes not REI compatible

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -316,6 +316,10 @@ file = "mods/rhino.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/roughly-enough-items-hacks.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/rubidium-extra.pw.toml"
 metafile = true
 

--- a/mods/roughly-enough-items-hacks.pw.toml
+++ b/mods/roughly-enough-items-hacks.pw.toml
@@ -1,0 +1,13 @@
+name = "REI Plugin Compatibilities"
+filename = "REIPluginCompatibilities-forge-9.0.90.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/1PfY6b5p/versions/VRug9EYM/REIPluginCompatibilities-forge-9.0.90.jar"
+hash-format = "sha1"
+hash = "6147cba9d73f274cf59249d724571abc2aa0e949"
+
+[update]
+[update.modrinth]
+mod-id = "1PfY6b5p"
+version = "VRug9EYM"


### PR DESCRIPTION
Adds the REI hack to make create recipes work
I thought it was just needed for create metallurgy but it seems its needed for create recipes.
