### PR TITLE
feat(mekanism): disable tin generation

### DIFF
--- a/config/Mekanism/world.toml
+++ b/config/Mekanism/world.toml
@@ -1,0 +1,6 @@
+[world_generation]
+	#Generation Settings for tin ore.
+	[world_generation.tin]
+		#Determines if tin ore should be added to world generation.
+        # We use thermal tin so this should be false
+		shouldGenerate = false

--- a/index.toml
+++ b/index.toml
@@ -4,6 +4,9 @@ hash-format = "sha256"
 file = "LICENSE"
 
 [[files]]
+file = "config/Mekanism/world.toml"
+
+[[files]]
 file = "config/forgery/features.ini"
 
 [[files]]


### PR DESCRIPTION
Thermal already has tin ore that looks better. Almost unified already prefers thermal tin ore. Mekanism tin ore should not generate in the world.

closes #68 