### PR TITLE
feat(mobs): blazes in volcanic areas

### DIFF
--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -1,13 +1,43 @@
 [
-  {
-    "dimension": "minecraft:overworld",
-    "mob": "minecraft:blaze",
-    "biome": ["terralith:cave/deep_caves", "terralith:cave/mantle_caves"],
-    "result": "allow"
-  },
-  {
-    "dimension": "minecraft:overworld",
-    "mob": "minecraft:blaze",
-    "result": "deny"
-  }
+    {
+        "dimension": "minecraft:overworld",
+        "mob": "minecraft:blaze",
+        "biome": ["terralith:cave/deep_caves", "terralith:cave/mantle_caves"],
+        "maxcount": 5,
+        "maxlight": 7,
+        "result": "allow"
+    },
+    {
+        "dimension": "minecraft:overworld",
+        "mob": "minecraft:blaze",
+        "biome": ["terralith:volcanic_crater"],
+        "block": [
+            "minecraft:basalt",
+            "minecraft:smooth_basalt",
+            "minecraft:blackstone",
+            "minecraft:magma_block"
+        ],
+        "maxcount": 30,
+        "result": "allow"
+    },
+    {
+        "dimension": "minecraft:overworld",
+        "mob": "minecraft:blaze",
+        "biome": ["terralith:volcanic_peaks"],
+        "block": [
+            "minecraft:basalt",
+            "minecraft:smooth_basalt",
+            "minecraft:blackstone",
+            "minecraft:magma_block"
+        ],
+        "maxcount": 10,
+        "random": 0.5,
+        "result": "allow"
+    },
+
+    {
+        "dimension": "minecraft:overworld",
+        "mob": "minecraft:blaze",
+        "result": "deny"
+    }
 ]

--- a/config/incontrol/spawner.json
+++ b/config/incontrol/spawner.json
@@ -1,23 +1,42 @@
 [
-  {
-    "mob": "minecraft:blaze",
-    "persecond": 1,
-    "attempts": 2,
-    "amount": {
-      "minimum": 1,
-      "maximum": 2
+    {
+        "mob": "minecraft:blaze",
+        "persecond": 0.5,
+        "attempts": 20,
+        "amount": {
+            "minimum": 2,
+            "maximum": 3
+        },
+        "conditions": {
+            "dimension": "minecraft:overworld",
+            "inwater": false,
+            "inlava": false,
+            "inair": false,
+            "mindist": 24,
+            "maxdist": 120,
+            "minheight": 50,
+            "maxheight": 200,
+            "norestrictions": true
+        }
     },
-    "conditions": {
-      "dimension": "minecraft:overworld",
-      "inwater": false,
-      "inlava": false,
-      "inair": false,
-      "mindist": 24,
-      "maxdist": 120,
-      "minheight": -60,
-      "maxheight": -45,
-      "maxthis": 20,
-      "norestrictions": true
+    {
+        "mob": "minecraft:blaze",
+        "persecond": 0.5,
+        "attempts": 10,
+        "amount": {
+            "minimum": 1,
+            "maximum": 2
+        },
+        "conditions": {
+            "dimension": "minecraft:overworld",
+            "inwater": false,
+            "inlava": false,
+            "inair": false,
+            "mindist": 24,
+            "maxdist": 120,
+            "minheight": -60,
+            "maxheight": -50,
+            "norestrictions": true
+        }
     }
-  }
 ]


### PR DESCRIPTION
Spawns blazes in volcanic areas. they can only spawn on certain blocks and they spawn in higher numbers there.  blazes have been reduced in underground and lowered an extra 5 blocks.  I can't get blazes to not spawn in the rain when above ground because I don't understand the rule system well enough.

closes #63 