### PR TITLE
feat: Bronze hand

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -46,6 +46,9 @@ file = "defaultconfigs/create-server.toml"
 file = "kubejs/README.txt"
 
 [[files]]
+file = "kubejs/assets/create/lang/en_us.json"
+
+[[files]]
 file = "kubejs/assets/flopper/textures/blocks/flopper_inside.png"
 
 [[files]]

--- a/kubejs/assets/create/lang/en_us.json
+++ b/kubejs/assets/create/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+    "item.create.brass_hand": "Bronze hand"
+}

--- a/kubejs/server_scripts/crafting.js
+++ b/kubejs/server_scripts/crafting.js
@@ -342,4 +342,11 @@ ServerEvents.recipes((event) => {
             B: "create:copper_casing",
         })
         .id("flopper:recipes/flopper");
+
+    // Bronze hand
+    event.replaceInput(
+        { output: "create:brass_hand" },
+        "create:brass_sheet",
+        "#forge:plates/bronze",
+    );
 });

--- a/kubejs/server_scripts/crafting.js
+++ b/kubejs/server_scripts/crafting.js
@@ -349,4 +349,10 @@ ServerEvents.recipes((event) => {
         "create:brass_sheet",
         "#forge:plates/bronze",
     );
+    // electron tube can only be crafted by deployer. that would be dependancy loop
+    event.replaceInput(
+        { output: "create:deployer" },
+        "create:electron_tube",
+        "create:shaft_tier_0",
+    );
 });


### PR DESCRIPTION
renames the brass hand to bronze hand
It now uses bronze to make.
The deployer no longer uses an electron tube and instead uses a tier 0 shaft. this might be too cheap...