### PR TITLE
chore: use npm for better dx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 .vscode
-reload.sh
 kubejs/.idea
 refresh.bat
 reload.bat
 serve.bat
 update-fork.bat
 index.toml
+node_modules
+.env

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm test

--- a/.packwizignore
+++ b/.packwizignore
@@ -5,10 +5,14 @@
 /README.asc
 # Exclude everthing begining with a dot because it should only be editor stuff.
 /.*
+#exclude node stuff
+package.json
+package-lock.json
+node_modules
+reload.sh
 # probe stuff should not be necessary.
 /kubejs/probe
-# Aiz reload script
-/reload.sh
+
 # Star's scripts
 kubejs/.idea
 refresh.bat

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 config/item_obliterator.json5
+kubejs/probe

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Instructions are based on the [packwiz installer tutorial](https://packwiz.infra
 
 3. To install the modpack you need to to use a launcher that supports running prelaunch tasks.[^tasknote]
 
--   We recommend [Prism Launcher](https://prismlauncher.org/).
+- We recommend [Prism Launcher](https://prismlauncher.org/).
 
 4. Create an instance matching the minecraft and modloader version the modpack uses.
    |Name |Version|
@@ -68,5 +68,7 @@ To prevent merge conflicts we have enabled the [packwiz option](https://packwiz.
 > Because of this please make sure to run `packwiz refresh` before adding files to commit.
 
 [^installnote]: We haven't published this modpack anywhere yet so this is currently the only way to install it.
+
 [^tasknote]: Pre launch tasks are not really required but it simplifys things.
+
 [^portnote]: This should default to http://localhost:8080/pack.toml. The same url we entered in the pre-launch command field.

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,6 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "6f4432ac058a71840278fb64eebdaec39752a9bfb8383cb4a1ad6d2f1ea7b4d2"
 
 [versions]
 forge = "43.3.0"

--- a/pack.toml
+++ b/pack.toml
@@ -6,6 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
+hash = "6f4432ac058a71840278fb64eebdaec39752a9bfb8383cb4a1ad6d2f1ea7b4d2"
 
 [versions]
 forge = "43.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
             "devDependencies": {
                 "env-cmd": "^10.1.0",
                 "husky": "^9.1.7",
-                "prettier": "^3.5.2"
+                "prettier": "^3.5.2",
+                "toml": "^3.0.0"
             }
         },
         "node_modules/cross-spawn": {
@@ -142,6 +143,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/toml": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+            "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+            "dev": true,
+            "license": "MIT"
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.1",
             "devDependencies": {
                 "env-cmd": "^10.1.0",
+                "husky": "^9.1.7",
                 "prettier": "^3.5.2"
             }
         },
@@ -26,13 +27,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/cross-spawn/node_modules/isexe": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/cross-spawn/node_modules/which": {
             "version": "2.0.2",
@@ -76,6 +70,29 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/husky": {
+            "version": "9.1.7",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+            "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "husky": "bin.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/typicode"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/path-key": {
             "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,130 @@
+{
+    "name": "create-grand-expanse",
+    "version": "0.0.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "create-grand-expanse",
+            "version": "0.0.1",
+            "devDependencies": {
+                "env-cmd": "^10.1.0",
+                "prettier": "^3.5.2"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/cross-spawn/node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/cross-spawn/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/env-cmd": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+            "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^4.0.0",
+                "cross-spawn": "^7.0.0"
+            },
+            "bin": {
+                "env-cmd": "bin/env-cmd.js"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/env-cmd/node_modules/commander": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
+            "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     },
     "scripts": {
         "dev": "packwiz serve --port $npm_package_config_port",
-        "reload": "env-cmd -- ./reload.sh"
+        "reload": "env-cmd -- ./reload.sh",
+        "format": "prettier . --write"
     },
     "devDependencies": {
         "env-cmd": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "create-grand-expanse",
+    "version": "0.0.1",
+    "private": true,
+    "config": {
+        "port": 8080
+    },
+    "scripts": {
+        "dev": "packwiz serve --port $npm_package_config_port",
+        "reload": "env-cmd -- ./reload.sh"
+    },
+    "devDependencies": {
+        "env-cmd": "^10.1.0",
+        "prettier": "^3.5.2"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -8,10 +8,14 @@
     "scripts": {
         "dev": "packwiz serve --port $npm_package_config_port",
         "reload": "env-cmd -- ./reload.sh",
-        "format": "prettier . --write"
+        "format": "prettier . --write",
+        "refresh": "packwiz refresh",
+        "prepare": "husky",
+        "test": "npm run refresh"
     },
     "devDependencies": {
         "env-cmd": "^10.1.0",
+        "husky": "^9.1.7",
         "prettier": "^3.5.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "create-grand-expanse",
     "version": "0.0.1",
     "private": true,
+    "type": "module",
     "config": {
         "port": 8080
     },
@@ -11,11 +12,13 @@
         "format": "prettier . --write",
         "refresh": "packwiz refresh",
         "prepare": "husky",
-        "test": "npm run refresh"
+        "check-hash": "node test.js",
+        "test": "npm run check-hash"
     },
     "devDependencies": {
         "env-cmd": "^10.1.0",
         "husky": "^9.1.7",
-        "prettier": "^3.5.2"
+        "prettier": "^3.5.2",
+        "toml": "^3.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "scripts": {
         "dev": "packwiz serve --port $npm_package_config_port",
         "reload": "env-cmd -- ./reload.sh",
+        "postreload": "npm run refresh",
         "format": "prettier . --write",
         "refresh": "packwiz refresh",
         "prepare": "husky",

--- a/reload.sh
+++ b/reload.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd $MINECRAFT_INSTANCE
+java -jar packwiz-installer-bootstrap.jar --bootstrap-no-update -g http://localhost:$npm_package_config_port/pack.toml

--- a/test.js
+++ b/test.js
@@ -1,0 +1,16 @@
+import { parse } from "toml";
+import { readFile } from "node:fs";
+import { strict as assert } from "node:assert";
+const pack = "./pack.toml";
+readFile(pack, (err, data) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    const hashExists = "hash" in parse(data)["index"];
+    assert.strictEqual(
+        hashExists,
+        false,
+        "Property index.hash exits in pack.toml"
+    );
+});


### PR DESCRIPTION
- Locks prettier to a specific version
- multiple scripts for common stuff
  - `dev` run packwiz serve
  - `reload` hopefully cross platform reload. make sure to set `MINECRAFT_INSTANCE` in a .env file
  - `format` run prettier
  - `refresh` packwiz refresh 
- pre commit hook to check for hash


its possible to add a build step now if we ever need to.


make sure you have npm and run npm install